### PR TITLE
Allow restart after refreshing the secret

### DIFF
--- a/pkg/rotator/rotator.go
+++ b/pkg/rotator/rotator.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/pem"
+	"flag"
 	"fmt"
 	"math/big"
 	"os"
@@ -46,6 +47,12 @@ var crLog = logf.Log.WithName("cert-rotation")
 var vwhGVK = schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: "ValidatingWebhookConfiguration"}
 
 var _ manager.Runnable = &CertRotator{}
+
+var restartOnSecretRefresh = false
+
+func init() {
+	flag.BoolVar(&restartOnSecretRefresh, "cert-restart-on-secret-refresh", false, "Kills the process when secrets are refreshed so that the pod can be restarted (secrets take up to 60s to be updated by running pods)")
+}
 
 // AddRotator adds the CertRotator and ReconcileVWH to the manager.
 func AddRotator(mgr manager.Manager, cr *CertRotator, vwhName string) error {
@@ -129,6 +136,10 @@ func (cr *CertRotator) refreshCertIfNeeded() error {
 				return false, nil
 			}
 			crLog.Info("server certs refreshed")
+			if restartOnSecretRefresh {
+				crLog.Info("Secrets have been updated; exiting so pod can be restarted (omit --cert-restart-on-secret-refresh to wait instead of restarting")
+				os.Exit(0)
+			}
 			return true, nil
 		}
 		// make sure our reconciler is initialized on startup (either this or the above refreshCerts() will call this)
@@ -139,6 +150,10 @@ func (cr *CertRotator) refreshCertIfNeeded() error {
 				return false, nil
 			}
 			crLog.Info("server certs refreshed")
+			if restartOnSecretRefresh {
+				crLog.Info("Secrets have been updated; exiting so pod can be restarted (omit --cert-restart-on-secret-refresh to wait instead of restarting")
+				os.Exit(0)
+			}
 			return true, nil
 		}
 		crLog.Info("no cert refresh needed")


### PR DESCRIPTION
See issue #2. This change can reduce the effective startup time of a
controller after its first installation from ~100s to ~10s, because we
no longer wait for the kubelet to project the new value of the secret.

This is almost identical to the code in HNC (see
https://github.com/kubernetes-sigs/multi-tenancy/pull/836). The only
difference is that this change restarts in _both_ codepaths where the
secrets are refreshed, while HNC only restarts when the secret
previously contained no valid data at all. This is almost certainly
unnecessary and has no impact, but is easier to understand.

Tested: the HNC code has worked reliably for about a month. While this
change is slightly different to that of HNC, note that the feature is
opt-in and initially I only expect HNC to use it. So I think this
sufficient testing to release a very early version of cert-controller,
import it into HNC, and test it there over the long term.

Fixes #2 