### PR TITLE
Add DNSName to SAN for go1.15 CN deprecation

### DIFF
--- a/pkg/rotator/rotator.go
+++ b/pkg/rotator/rotator.go
@@ -318,6 +318,9 @@ func (cr *CertRotator) createCACert() (*KeyPairArtifacts, error) {
 			CommonName:   cr.CAName,
 			Organization: []string{cr.CAOrganization},
 		},
+		DNSNames: []string{
+			cr.CAName,
+		},
 		NotBefore:             begin,
 		NotAfter:              end,
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
@@ -354,6 +357,9 @@ func (cr *CertRotator) createCertPEM(ca *KeyPairArtifacts) ([]byte, []byte, erro
 		SerialNumber: big.NewInt(1),
 		Subject: pkix.Name{
 			CommonName: cr.DNSName,
+		},
+		DNSNames: []string{
+			cr.DNSName,
 		},
 		NotBefore:             begin,
 		NotAfter:              end,


### PR DESCRIPTION
This change is identical to
https://github.com/open-policy-agent/gatekeeper/pull/811 and fixes
cert-controller on K8s 1.19+.

Tested: imported cert-controller with this change into HNC and verified
that without this change, HNC won't start on KIND 1.19, but with this
change, HNC's e2e tests work correctly.