### PR TITLE
Allow cert rotator to work on multiple webhooks

### DIFF
--- a/pkg/rotator/rotator.go
+++ b/pkg/rotator/rotator.go
@@ -45,16 +45,40 @@ const (
 
 var crLog = logf.Log.WithName("cert-rotation")
 
-var vwhGVK = schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: "ValidatingWebhookConfiguration"}
+//WebhookType it the type of webhook, either validating/mutating webhook or a CRD conversion webhook
+type WebhookType int
 
-var crdGVK = schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1beta1", Kind: "CustomResourceDefinition"}
+const (
+	//ValidatingWebhook indicates the webhook is a ValidatingWebhook
+	Validating WebhookType = iota
+	//MutingWebhook indicates the webhook is a MutatingWebhook
+	Mutating
+	//CRDConversionWebhook indicates the webhook is a conversion webhook
+	CRDConversion
+)
 
 var _ manager.Runnable = &CertRotator{}
 
 var restartOnSecretRefresh = false
 
+//WebhookInfo is used by the rotator to receive info about resources to be updated with certificates
+type WebhookInfo struct {
+	//Name is the name of the webhook for a validating or mutating webhook, or the CRD name in case of a CRD conversion webhook
+	Name string
+	Type WebhookType
+}
+
 func init() {
 	flag.BoolVar(&restartOnSecretRefresh, "cert-restart-on-secret-refresh", false, "Kills the process when secrets are refreshed so that the pod can be restarted (secrets take up to 60s to be updated by running pods)")
+}
+
+func (w WebhookInfo) gvk() schema.GroupVersionKind {
+	t2g := map[WebhookType]schema.GroupVersionKind{
+		Validating:    schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: "ValidatingWebhookConfiguration"},
+		Mutating:      schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: "MutatingWebhookConfiguration"},
+		CRDConversion: schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1beta1", Kind: "CustomResourceDefinition"},
+	}
+	return t2g[w.Type]
 }
 
 // AddRotator adds the CertRotator and ReconcileWH to the manager.
@@ -68,15 +92,13 @@ func AddRotator(mgr manager.Manager, cr *CertRotator) error {
 		return err
 	}
 
-	vwhKey := types.NamespacedName{Name: cr.VWHName}
 	reconciler := &ReconcileWH{
 		client:        mgr.GetClient(),
 		scheme:        mgr.GetScheme(),
 		ctx:           context.Background(),
 		secretKey:     cr.SecretKey,
-		vwhKey:        vwhKey,
-		crdNames:      cr.CRDNames,
 		wasCAInjected: cr.wasCAInjected,
+		webhooks:      cr.Webhooks,
 	}
 	if err := addController(mgr, reconciler); err != nil {
 		return err
@@ -93,12 +115,11 @@ type CertRotator struct {
 	CAOrganization  string
 	DNSName         string
 	IsReady         chan struct{}
+	Webhooks        []WebhookInfo
 	certsMounted    chan struct{}
 	certsNotMounted chan struct{}
 	wasCAInjected   *atomic.Bool
 	caNotInjected   chan struct{}
-	VWHName         string
-	CRDNames        []string
 }
 
 // Start starts the CertRotator runnable to rotate certs and ensure the certs are ready.
@@ -211,8 +232,20 @@ func (cr *CertRotator) refreshCerts(refreshCA bool, secret *corev1.Secret) error
 	return nil
 }
 
-func injectCertToWebhook(vwh *unstructured.Unstructured, certPem []byte) error {
-	webhooks, found, err := unstructured.NestedSlice(vwh.Object, "webhooks")
+func injectCert(updatedResource *unstructured.Unstructured, certPem []byte, webhookType WebhookType) error {
+	switch webhookType {
+	case Validating:
+		return injectCertToWebhook(updatedResource, certPem)
+	case Mutating:
+		return injectCertToWebhook(updatedResource, certPem)
+	case CRDConversion:
+		return injectCertToConversionWebhook(updatedResource, certPem)
+	}
+	return fmt.Errorf("Incorrect webhook type")
+}
+
+func injectCertToWebhook(wh *unstructured.Unstructured, certPem []byte) error {
+	webhooks, found, err := unstructured.NestedSlice(wh.Object, "webhooks")
 	if err != nil {
 		return err
 	}
@@ -229,7 +262,7 @@ func injectCertToWebhook(vwh *unstructured.Unstructured, certPem []byte) error {
 		}
 		webhooks[i] = hook
 	}
-	if err := unstructured.SetNestedSlice(vwh.Object, webhooks, "webhooks"); err != nil {
+	if err := unstructured.SetNestedSlice(wh.Object, webhooks, "webhooks"); err != nil {
 		return err
 	}
 	return nil
@@ -482,14 +515,14 @@ var _ handler.Mapper = &mapper{}
 
 type mapper struct {
 	secretKey types.NamespacedName
-	vwhKey    types.NamespacedName
+	whKey     types.NamespacedName
 }
 
 func (m *mapper) Map(object handler.MapObject) []reconcile.Request {
-	if object.Meta.GetNamespace() != m.vwhKey.Namespace {
+	if object.Meta.GetNamespace() != m.whKey.Namespace {
 		return nil
 	}
-	if object.Meta.GetName() != m.vwhKey.Name {
+	if object.Meta.GetName() != m.whKey.Name {
 		return nil
 	}
 	return []reconcile.Request{{NamespacedName: m.secretKey}}
@@ -497,21 +530,17 @@ func (m *mapper) Map(object handler.MapObject) []reconcile.Request {
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func addController(mgr manager.Manager, r *ReconcileWH) error {
-	vwh := &unstructured.Unstructured{}
-	vwh.SetGroupVersionKind(vwhGVK)
-	crd := &unstructured.Unstructured{}
-	crd.SetGroupVersionKind(crdGVK)
 	// Create a new controller
-	err := ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Secret{}).
-		Watches(&source.Kind{Type: vwh}, &handler.EnqueueRequestsFromMapFunc{ToRequests: &mapper{
+	builder := ctrl.NewControllerManagedBy(mgr).For(&corev1.Secret{})
+	for _, webhook := range r.webhooks {
+		wh := &unstructured.Unstructured{}
+		wh.SetGroupVersionKind(webhook.gvk())
+		builder = builder.Watches(&source.Kind{Type: wh}, &handler.EnqueueRequestsFromMapFunc{ToRequests: &mapper{
 			secretKey: r.secretKey,
-			vwhKey:    r.vwhKey,
-		}}).
-		Watches(&source.Kind{Type: crd}, &handler.EnqueueRequestsFromMapFunc{ToRequests: &crdMapper{
-			secretKey: r.secretKey,
-			crdNames:  r.crdNames,
-		}}).Complete(r)
+			whKey:     types.NamespacedName{Name: webhook.Name},
+		}})
+	}
+	err := builder.Complete(r)
 	if err != nil {
 		return err
 	}
@@ -528,8 +557,7 @@ type ReconcileWH struct {
 	scheme        *runtime.Scheme
 	ctx           context.Context
 	secretKey     types.NamespacedName
-	vwhKey        types.NamespacedName
-	crdNames      []string
+	webhooks      []WebhookInfo
 	wasCAInjected *atomic.Bool
 }
 
@@ -557,18 +585,9 @@ func (r *ReconcileWH) Reconcile(request reconcile.Request) (reconcile.Result, er
 			return reconcile.Result{}, nil
 		}
 
-		// Ensure certs on validating webhooks.
-		errVWH := r.ensureVWHCerts(artifacts.CertPEM)
-
-		// Ensure certs on CRD conversion webhooks if there's any.
-		errCWH := r.ensureCRDConvWHCerts(artifacts.CertPEM)
-
-		// Return errors if there's any when trying to inject certs to all webhooks.
-		if errVWH != nil {
-			return reconcile.Result{}, errVWH
-		}
-		if errCWH != nil {
-			return reconcile.Result{}, errCWH
+		// Ensure certs on webhooks
+		if err := r.ensureCerts(artifacts.CertPEM); err != nil {
+			return reconcile.Result{}, err
 		}
 
 		// Set CAInjected if the reconciler has not exited early.
@@ -578,66 +597,50 @@ func (r *ReconcileWH) Reconcile(request reconcile.Request) (reconcile.Result, er
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileWH) ensureVWHCerts(certPem []byte) error {
-	vwh := &unstructured.Unstructured{}
-	vwh.SetGroupVersionKind(vwhGVK)
-	if err := r.client.Get(r.ctx, r.vwhKey, vwh); err != nil {
-		if k8sErrors.IsNotFound(err) {
-			crLog.Info("VWK " + r.vwhKey.Name + " is not found. No action is needed.")
-			return nil
-		}
-		// Error reading the object - requeue the request.
-		return err
-	}
-
-	crLog.Info("ensuring CA cert on ValidatingWebhookConfiguration")
-	if err := injectCertToWebhook(vwh, certPem); err != nil {
-		crLog.Error(err, "unable to inject cert to webhook")
-		return err
-	}
-	if err := r.client.Update(r.ctx, vwh); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// ensureCRDConvWHCerts returns an arbitrary error if multiple errors are
-// encountered, while all the errors are logged.
-func (r *ReconcileWH) ensureCRDConvWHCerts(certPem []byte) error {
+// ensureCerts returns an arbitrary error if multiple errors are encountered,
+// while all the errors are logged.
+// This is important to allow the controller to reconcile the secret. If an error
+// is returned, request will be requeued, and the controller will attempt to reconcile
+// the secret again.
+// When an error is encountered for when processing a webhook, the error is logged, but
+// following webhooks are also attempted to be updated. If multiple errors occur for different
+// webhooks, only the last one will be returned. This is ok, as the returned error is only meant
+// to indicate that reconciliation failed. The information about all the errors is passed not
+// by the returned error, but rather in the logged errors.
+func (r *ReconcileWH) ensureCerts(certPem []byte) error {
 	var anyError error = nil
-	for _, crdName := range r.crdNames {
-		crd := &unstructured.Unstructured{}
-		crd.SetGroupVersionKind(crdGVK)
-		crdKey := types.NamespacedName{Name: crdName}
-		if err := r.client.Get(r.ctx, crdKey, crd); err != nil {
+
+	for _, webhook := range r.webhooks {
+		gvk := webhook.gvk()
+		log := crLog.WithValues("name", webhook.Name, "gvk", gvk)
+		updatedResource := &unstructured.Unstructured{}
+		updatedResource.SetGroupVersionKind(gvk)
+		if err := r.client.Get(r.ctx, types.NamespacedName{Name: webhook.Name}, updatedResource); err != nil {
 			if k8sErrors.IsNotFound(err) {
-				crLog.Info("CRD " + crdName + " is not found")
+				log.Error(err, "Webhook not found. Unable to update certificate.")
 				continue
 			}
-			// Error reading the object - requeue the request.
-			crLog.Error(err, "unable to get CRD")
 			anyError = err
+			log.Error(err, "Error getting webhook for certificate update.")
+			continue
+		}
+		if !updatedResource.GetDeletionTimestamp().IsZero() {
+			log.Info("Webhook is being deleted. Unable to update certificate")
 			continue
 		}
 
-		if !crd.GetDeletionTimestamp().IsZero() {
-			crLog.Info("CRD " + crdName + " is being deleted")
-			continue
-		}
-
-		crLog.Info("ensuring CA cert on CRD conversion webhook")
-		if err := injectCertToConversionWebhook(crd, certPem); err != nil {
-			crLog.Error(err, "unable to inject cert to CRD conversion webhook")
+		log.Info("Ensuring CA cert", "name", webhook.Name, "gvk", gvk)
+		if err := injectCert(updatedResource, certPem, webhook.Type); err != nil {
+			log.Error(err, "Unable to inject cert to webhook.")
 			anyError = err
 			continue
 		}
-		if err := r.client.Update(r.ctx, crd); err != nil {
-			crLog.Error(err, "unable to update cert on CRD "+crdName)
+		if err := r.client.Update(r.ctx, updatedResource); err != nil {
+			log.Error(err, "Error updating webhook with certificate")
 			anyError = err
+			continue
 		}
 	}
-
 	return anyError
 }
 


### PR DESCRIPTION
The gatekeeper mutation feature will require a new mutating webhook to be added. The current cert rotator code only allowed to handle a single validating webhook. 
This change modifies the cert rotator to handle an array of webhooks (name and type).
An matching PR on the gatekeeper side [(here)](https://github.com/open-policy-agent/gatekeeper/pull/881) is needed along with this.

Tested:
The PR was validated together with gatekeeper in 2 ways:
    - with gatekeeper as is, an incoming resource was succesfully validated.
    - with gatekeeper PR 881 (https://github.com/open-policy-agent/gatekeeper/pull/881),
      which adds a mutating webhook. In this case an incoming resource was
      succesfuly mutated.
    