### PR TITLE
feat: ability to add additional key usages to webhook certificate

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -13,13 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Set up Go 1.17
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.38.0
+          version: v1.46.2
           args: --timeout 5m
 
   test:

--- a/pkg/rotator/rotator.go
+++ b/pkg/rotator/rotator.go
@@ -147,20 +147,22 @@ type SyncingReader interface {
 
 // CertRotator contains cert artifacts and a channel to close when the certs are ready.
 type CertRotator struct {
-	reader                 SyncingReader
-	writer                 client.Writer
-	SecretKey              types.NamespacedName
-	CertDir                string
-	CAName                 string
-	CAOrganization         string
-	DNSName                string
-	IsReady                chan struct{}
-	Webhooks               []WebhookInfo
-	RestartOnSecretRefresh bool
-	certsMounted           chan struct{}
-	certsNotMounted        chan struct{}
-	wasCAInjected          *atomic.Bool
-	caNotInjected          chan struct{}
+	reader                      SyncingReader
+	writer                      client.Writer
+	SecretKey                   types.NamespacedName
+	CertDir                     string
+	CAName                      string
+	CAOrganization              string
+	DNSName                     string
+	IsReady                     chan struct{}
+	Webhooks                    []WebhookInfo
+	RestartOnSecretRefresh      bool
+	EnableExtKeyUsageClientAuth bool
+	extKeyUsages                []x509.ExtKeyUsage
+	certsMounted                chan struct{}
+	certsNotMounted             chan struct{}
+	wasCAInjected               *atomic.Bool
+	caNotInjected               chan struct{}
 }
 
 // Start starts the CertRotator runnable to rotate certs and ensure the certs are ready.
@@ -170,6 +172,11 @@ func (cr *CertRotator) Start(ctx context.Context) error {
 	}
 	if !cr.reader.WaitForCacheSync(ctx) {
 		return errors.New("failed waiting for reader to sync")
+	}
+
+	cr.extKeyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	if cr.EnableExtKeyUsageClientAuth {
+		cr.extKeyUsages = append(cr.extKeyUsages, x509.ExtKeyUsageClientAuth)
 	}
 
 	// explicitly rotate on the first round so that the certificate
@@ -459,7 +466,7 @@ func (cr *CertRotator) CreateCertPEM(ca *KeyPairArtifacts, begin, end time.Time)
 		NotBefore:             begin,
 		NotAfter:              end,
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		ExtKeyUsage:           cr.extKeyUsages,
 		BasicConstraintsValid: true,
 	}
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -495,7 +502,7 @@ func lookaheadTime() time.Time {
 }
 
 func (cr *CertRotator) validServerCert(caCert, cert, key []byte) bool {
-	valid, err := ValidCert(caCert, cert, key, cr.DNSName, lookaheadTime())
+	valid, err := ValidCert(caCert, cert, key, cr.DNSName, cr.extKeyUsages, lookaheadTime())
 	if err != nil {
 		return false
 	}
@@ -503,14 +510,14 @@ func (cr *CertRotator) validServerCert(caCert, cert, key []byte) bool {
 }
 
 func (cr *CertRotator) validCACert(cert, key []byte) bool {
-	valid, err := ValidCert(cert, cert, key, cr.CAName, lookaheadTime())
+	valid, err := ValidCert(cert, cert, key, cr.CAName, nil, lookaheadTime())
 	if err != nil {
 		return false
 	}
 	return valid
 }
 
-func ValidCert(caCert, cert, key []byte, dnsName string, at time.Time) (bool, error) {
+func ValidCert(caCert, cert, key []byte, dnsName string, keyUsages []x509.ExtKeyUsage, at time.Time) (bool, error) {
 	if len(caCert) == 0 || len(cert) == 0 || len(key) == 0 {
 		return false, errors.New("empty cert")
 	}
@@ -544,6 +551,7 @@ func ValidCert(caCert, cert, key []byte, dnsName string, at time.Time) (bool, er
 		DNSName:     dnsName,
 		Roots:       pool,
 		CurrentTime: at,
+		KeyUsages:   keyUsages,
 	})
 	if err != nil {
 		return false, errors.Wrap(err, "verifying cert")

--- a/pkg/rotator/rotator.go
+++ b/pkg/rotator/rotator.go
@@ -545,12 +545,17 @@ func ValidCert(caCert, cert, key []byte, dnsName string, keyUsages *[]x509.ExtKe
 	if err != nil {
 		return false, errors.Wrap(err, "parsing cert")
 	}
-	_, err = crt.Verify(x509.VerifyOptions{
+
+	opt := x509.VerifyOptions{
 		DNSName:     dnsName,
 		Roots:       pool,
 		CurrentTime: at,
-		KeyUsages:   *keyUsages,
-	})
+	}
+	if keyUsages != nil {
+		opt.KeyUsages = *keyUsages
+	}
+
+	_, err = crt.Verify(opt)
 	if err != nil {
 		return false, errors.Wrap(err, "verifying cert")
 	}

--- a/pkg/rotator/rotator_test.go
+++ b/pkg/rotator/rotator_test.go
@@ -2,6 +2,7 @@ package rotator
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"testing"
 	"time"
@@ -22,10 +23,13 @@ import (
 
 var (
 	cr = &CertRotator{
-		CAName:                      "ca",
-		CAOrganization:              "org",
-		DNSName:                     "service.namespace",
-		EnableExtKeyUsageClientAuth: true,
+		CAName:         "ca",
+		CAOrganization: "org",
+		DNSName:        "service.namespace",
+		ExtKeyUsages: &[]x509.ExtKeyUsage{
+			x509.ExtKeyUsageClientAuth,
+			x509.ExtKeyUsageServerAuth,
+		},
 	}
 	//certValidityDuration = 10 * 365 * 24 * time.Hour
 	begin = time.Now().Add(-1 * time.Hour)
@@ -63,7 +67,7 @@ func TestCertExpiry(t *testing.T) {
 		t.Error("Generated cert is not valid")
 	}
 
-	valid, err := ValidCert(caArtifacts.CertPEM, cert, key, cr.DNSName, cr.extKeyUsages, time.Now().Add(11*365*24*time.Hour))
+	valid, err := ValidCert(caArtifacts.CertPEM, cert, key, cr.DNSName, cr.ExtKeyUsages, time.Now().Add(11*365*24*time.Hour))
 	if err == nil {
 		t.Error("Generated cert has not expired when it should have")
 	}
@@ -114,7 +118,7 @@ func TestCAExpiry(t *testing.T) {
 		t.Error("Generated cert is not valid")
 	}
 
-	valid, err := ValidCert(caArtifacts.CertPEM, caArtifacts.CertPEM, caArtifacts.KeyPEM, cr.CAName, cr.extKeyUsages, time.Now().Add(11*365*24*time.Hour))
+	valid, err := ValidCert(caArtifacts.CertPEM, caArtifacts.CertPEM, caArtifacts.KeyPEM, cr.CAName, cr.ExtKeyUsages, time.Now().Add(11*365*24*time.Hour))
 	if err == nil {
 		t.Error("Generated cert has not expired when it should have")
 	}

--- a/pkg/rotator/rotator_test.go
+++ b/pkg/rotator/rotator_test.go
@@ -22,9 +22,10 @@ import (
 
 var (
 	cr = &CertRotator{
-		CAName:         "ca",
-		CAOrganization: "org",
-		DNSName:        "service.namespace",
+		CAName:                      "ca",
+		CAOrganization:              "org",
+		DNSName:                     "service.namespace",
+		EnableExtKeyUsageClientAuth: true,
 	}
 	//certValidityDuration = 10 * 365 * 24 * time.Hour
 	begin = time.Now().Add(-1 * time.Hour)
@@ -62,7 +63,7 @@ func TestCertExpiry(t *testing.T) {
 		t.Error("Generated cert is not valid")
 	}
 
-	valid, err := ValidCert(caArtifacts.CertPEM, cert, key, cr.DNSName, time.Now().Add(11*365*24*time.Hour))
+	valid, err := ValidCert(caArtifacts.CertPEM, cert, key, cr.DNSName, cr.extKeyUsages, time.Now().Add(11*365*24*time.Hour))
 	if err == nil {
 		t.Error("Generated cert has not expired when it should have")
 	}
@@ -113,7 +114,7 @@ func TestCAExpiry(t *testing.T) {
 		t.Error("Generated cert is not valid")
 	}
 
-	valid, err := ValidCert(caArtifacts.CertPEM, caArtifacts.CertPEM, caArtifacts.KeyPEM, cr.CAName, time.Now().Add(11*365*24*time.Hour))
+	valid, err := ValidCert(caArtifacts.CertPEM, caArtifacts.CertPEM, caArtifacts.KeyPEM, cr.CAName, cr.extKeyUsages, time.Now().Add(11*365*24*time.Hour))
 	if err == nil {
 		t.Error("Generated cert has not expired when it should have")
 	}


### PR DESCRIPTION
Design doc: [docs.google.com/document/d/1GjV3WeC2bgQ3j37_mMpY9hr7YOAqzSJ6jDSu-DVrcmU/edit#](https://docs.google.com/document/d/1GjV3WeC2bgQ3j37_mMpY9hr7YOAqzSJ6jDSu-DVrcmU/edit#)

To establish mTLS between Gatekeeper and external data provider, we need to grant `x509.ExtKeyUsageClientAuth` key usage to the webhook certificate.