### PR TITLE
Don't produce an error if there are no webhooks

### DIFF
--- a/pkg/rotator/rotator.go
+++ b/pkg/rotator/rotator.go
@@ -308,7 +308,7 @@ func injectCertToWebhook(wh *unstructured.Unstructured, certPem []byte) error {
 		return err
 	}
 	if !found {
-		return errors.New("`webhooks` field not found in ValidatingWebhookConfiguration")
+		return nil
 	}
 	for i, h := range webhooks {
 		hook, ok := h.(map[string]interface{})


### PR DESCRIPTION
kustomize or operators could result in having a webhook config with no webhooks. This shouldn't be an error.

This is a fix for https://github.com/open-policy-agent/cert-controller/issues/6.