### PR TITLE
feat: Add support to extra dns names

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The following code snippet is taken from the Gatekeeper project:
 			CAName:         caName,
 			CAOrganization: caOrganization,
 			DNSName:        dnsName,
+			ExtraDNSNames:  extraDnsNames,
 			IsReady:        setupFinished,
 			VWHName:        vwhName,
 		}); err != nil {

--- a/pkg/rotator/rotator.go
+++ b/pkg/rotator/rotator.go
@@ -476,8 +476,8 @@ func (cr *CertRotator) CreateCACert(begin, end time.Time) (*KeyPairArtifacts, er
 // CreateCertPEM takes the results of CreateCACert and uses it to create the
 // PEM-encoded public certificate and private key, respectively
 func (cr *CertRotator) CreateCertPEM(ca *KeyPairArtifacts, begin, end time.Time) ([]byte, []byte, error) {
-	dnsNames := cr.ExtraDNSNames
-	dnsNames = append(dnsNames, cr.DNSName)
+	dnsNames := []string{cr.DNSName}
+	dnsNames = append(dnsNames, cr.ExtraDNSNames...)
 	templ := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		Subject: pkix.Name{

--- a/pkg/rotator/rotator.go
+++ b/pkg/rotator/rotator.go
@@ -168,6 +168,7 @@ type CertRotator struct {
 	CAName                 string
 	CAOrganization         string
 	DNSName                string
+	ExtraDNSNames          []string
 	IsReady                chan struct{}
 	Webhooks               []WebhookInfo
 	RestartOnSecretRefresh bool
@@ -475,14 +476,14 @@ func (cr *CertRotator) CreateCACert(begin, end time.Time) (*KeyPairArtifacts, er
 // CreateCertPEM takes the results of CreateCACert and uses it to create the
 // PEM-encoded public certificate and private key, respectively
 func (cr *CertRotator) CreateCertPEM(ca *KeyPairArtifacts, begin, end time.Time) ([]byte, []byte, error) {
+	dnsNames := cr.ExtraDNSNames
+	dnsNames = append(dnsNames, cr.DNSName)
 	templ := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		Subject: pkix.Name{
 			CommonName: cr.DNSName,
 		},
-		DNSNames: []string{
-			cr.DNSName,
-		},
+		DNSNames:              dnsNames,
 		NotBefore:             begin,
 		NotAfter:              end,
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,

--- a/pkg/rotator/rotator_test.go
+++ b/pkg/rotator/rotator_test.go
@@ -26,6 +26,9 @@ var (
 		CAName:         "ca",
 		CAOrganization: "org",
 		DNSName:        "service.namespace",
+		ExtraDNSNames: []string{
+			"other-service.namespace",
+		},
 		ExtKeyUsages: &[]x509.ExtKeyUsage{
 			x509.ExtKeyUsageClientAuth,
 			x509.ExtKeyUsageServerAuth,
@@ -48,7 +51,12 @@ func TestCertSigning(t *testing.T) {
 	}
 
 	if !cr.validServerCert(caArtifacts.CertPEM, cert, key) {
-		t.Error("Generated cert is not valid")
+		t.Error("Generated cert is not valid for common name")
+	}
+
+	valid, err := ValidCert(caArtifacts.CertPEM, cert, key, cr.ExtraDNSNames[0], cr.ExtKeyUsages, lookaheadTime())
+	if err != nil || !valid {
+		t.Error("Generated cert is not valid for ExtraDnsName")
 	}
 }
 


### PR DESCRIPTION
In [KEDA](https://keda.sh/) we are integrating this solution as a "default not fully safe" for cert management. Our problem is that we have 3 different components, the admission webhooks, the operator and the metrics server and all of them should share the certs because we want to use them for some internal communications.
Using cert-manager or other solution, we can just create a certificate with multiple dns names and sharing the same secret, we can secure all the internal communications and also webhooks and api services, but for new adopters, the requirement of a 3rd party could be a problem, and that's why we want to introduce this project for certificate management in non-productive environments, but not having the option for setting multiple dns names block us.

Fixes https://github.com/open-policy-agent/cert-controller/issues/51