### PR TITLE
fix: default ExtKeyUsages early

### DIFF
--- a/pkg/rotator/rotator.go
+++ b/pkg/rotator/rotator.go
@@ -147,6 +147,10 @@ func AddRotator(mgr manager.Manager, cr *CertRotator) error {
 		cr.RotationCheckFrequency = defaultLookaheadInterval
 	}
 
+	if cr.ExtKeyUsages == nil {
+		cr.ExtKeyUsages = &[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	}
+
 	reconciler := &ReconcileWH{
 		cache:                       cache,
 		writer:                      mgr.GetClient(), // TODO
@@ -249,10 +253,6 @@ func (cr *CertRotator) Start(ctx context.Context) error {
 	}
 	if !cr.reader.WaitForCacheSync(ctx) {
 		return errors.New("failed waiting for reader to sync")
-	}
-
-	if cr.ExtKeyUsages == nil {
-		cr.ExtKeyUsages = &[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
 	}
 
 	// explicitly rotate on the first round so that the certificate


### PR DESCRIPTION
There is a pre-existing, pathological race condition in [`AddRotator`](https://github.com/open-policy-agent/cert-controller/blob/87e4e2f0a2901a5a46965daa85a61482a7181750/pkg/rotator/rotator.go#L100-L140) from which the `CertRotator.Start()` and the `ReconcileWh.Reconcile()` may race. Currently that race causes a panic if `ExtKeyUsages  == nil`.

This patch moves the defaulting of `ExtKeyUsages` to `AddRotator` (where `CertRotator` is created).