### PR TITLE
feat: ability to customize cert-rotator's controller name

### DIFF
--- a/pkg/rotator/rotator.go
+++ b/pkg/rotator/rotator.go
@@ -134,8 +134,8 @@ func AddRotator(mgr manager.Manager, cr *CertRotator) error {
 			return err
 		}
 	}
-	if cr.controllerName == "" {
-		cr.controllerName = defaultControllerName
+	if cr.ControllerName == "" {
+		cr.ControllerName = defaultControllerName
 	}
 	if cr.CertName == "" {
 		cr.CertName = defaultCertName
@@ -180,7 +180,7 @@ func AddRotator(mgr manager.Manager, cr *CertRotator) error {
 		certsNotMounted:             cr.certsNotMounted,
 		enableReadinessCheck:        cr.EnableReadinessCheck,
 	}
-	if err := addController(mgr, reconciler, cr.controllerName); err != nil {
+	if err := addController(mgr, reconciler, cr.ControllerName); err != nil {
 		return err
 	}
 	return nil
@@ -258,6 +258,10 @@ type CertRotator struct {
 	// runnable to finish execution.
 	EnableReadinessCheck bool
 
+	// ControllerName allows registering multiple cert-rotator controllers.
+	// Use the default value unless rotating multiple certificate secrets.
+	ControllerName string
+
 	certsMounted    chan struct{}
 	certsNotMounted chan struct{}
 	wasCAInjected   *atomic.Bool
@@ -266,10 +270,6 @@ type CertRotator struct {
 	// testNoBackgroundRotation doesn't actually start the rotator in the background.
 	// This should only be used for testing.
 	testNoBackgroundRotation bool
-	// controllerName allows setting the controller name to register it multiple times
-	// fixing the new k8s check that produces 'controller with name cert-rotator already exists'
-	// This should only be used for testing.
-	controllerName string
 }
 
 func (cr *CertRotator) NeedLeaderElection() bool {

--- a/pkg/rotator/rotator_test.go
+++ b/pkg/rotator/rotator_test.go
@@ -381,7 +381,7 @@ func TestReconcileWebhook(t *testing.T) {
 					},
 				},
 				FieldOwner:     fieldOwner,
-				controllerName: t.Name(),
+				ControllerName: t.Name(),
 			}
 			wh, ok := tt.webhookConfig.DeepCopyObject().(client.Object)
 			if !ok {
@@ -404,7 +404,7 @@ func TestReconcileWebhook(t *testing.T) {
 			whName = whName + "-2"
 
 			rotator := &CertRotator{
-				controllerName: t.Name(),
+				ControllerName: t.Name(),
 				SecretKey:      key,
 				Webhooks: []WebhookInfo{
 					{
@@ -442,7 +442,7 @@ func TestWebhookCARotation(t *testing.T) {
 		testNoBackgroundRotation: true,
 		CaCertDuration:           time.Duration(time.Second * 2),
 		ExtKeyUsages:             &[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		controllerName:           t.Name(),
+		ControllerName:           t.Name(),
 	}
 
 	wh := &admissionv1.ValidatingWebhookConfiguration{
@@ -533,7 +533,7 @@ func TestNamespacedCache(t *testing.T) {
 	key := types.NamespacedName{Namespace: "test-namespace-0", Name: "test-secret"}
 	rotator := &CertRotator{
 		SecretKey:      key,
-		controllerName: t.Name(),
+		ControllerName: t.Name(),
 	}
 	err := AddRotator(mgr, rotator)
 	g.Expect(err).NotTo(gomega.HaveOccurred(), "adding rotator")
@@ -674,7 +674,7 @@ func TestReconcilerSync(t *testing.T) {
 					testNoBackgroundRotation: true,
 					CaCertDuration:           time.Duration(time.Second * 2),
 					ExtKeyUsages:             &[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-					controllerName:           t.Name(),
+					ControllerName:           t.Name(),
 				}
 
 				wh := &admissionv1.ValidatingWebhookConfiguration{


### PR DESCRIPTION
If there are multiple certificate secrets (a mixed of webhook certs and non-webhook certs) in the same cluster that I would like to rotate, it's not possible to set up multiple cert-rotator at the moment because the controller name is fixed.