### PR TITLE
Harden CI downloads by adding checksum verification

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -59,22 +59,53 @@ jobs:
 
       - name: Install kubebuilder
         run: |
-          curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_$(go env GOOS)_$(go env GOARCH)" && \
-          curl -L -O "https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-server-$(go env GOOS)-$(go env GOARCH).tar.gz" && \
-          curl -L -O "https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-client-$(go env GOOS)-$(go env GOARCH).tar.gz" && \
-          curl -L -O "https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-$(go env GOOS)-$(go env GOARCH).tar.gz" && \
-          tar -zxvf kubernetes-server-$(go env GOOS)-$(go env GOARCH).tar.gz && \
-          tar -zxvf kubernetes-client-$(go env GOOS)-$(go env GOARCH).tar.gz && \
-          tar -zxvf etcd-v${ETCD_VERSION}-$(go env GOOS)-$(go env GOARCH).tar.gz && \
-          chmod +x kubebuilder_$(go env GOOS)_$(go env GOARCH) && \
-          chmod +x kubernetes/server/bin/kube-apiserver && \
-          chmod +x kubernetes/client/bin/kubectl && \
-          chmod +x etcd-v${ETCD_VERSION}-$(go env GOOS)-$(go env GOARCH)/etcd && \
-          sudo mkdir -p /usr/local/kubebuilder/bin && \
-          sudo mv kubebuilder_$(go env GOOS)_$(go env GOARCH) /usr/local/kubebuilder/bin/kubebuilder && \
-          sudo mv kubernetes/server/bin/kube-apiserver /usr/local/kubebuilder/bin/kube-apiserver && \
-          sudo mv kubernetes/server/bin/kubectl /usr/local/kubebuilder/bin/kubectl && \
-          sudo mv etcd-v${ETCD_VERSION}-$(go env GOOS)-$(go env GOARCH)/etcd /usr/local/kubebuilder/bin/etcd
+          set -euo pipefail
+
+          os="$(go env GOOS)"
+          arch="$(go env GOARCH)"
+
+          curl --fail --show-error --silent --location --remote-name \
+            "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${os}_${arch}"
+          curl --fail --show-error --silent --location --remote-name \
+            "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/checksums.txt"
+          grep " kubebuilder_${os}_${arch}$" checksums.txt | sha256sum --check --status
+
+          curl --fail --show-error --silent --location --remote-name \
+            "https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-server-${os}-${arch}.tar.gz"
+          curl --fail --show-error --silent --location --remote-name \
+            "https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-server-${os}-${arch}.tar.gz.sha256"
+          sha256sum --check --status <<EOF
+$(cat kubernetes-server-${os}-${arch}.tar.gz.sha256)  kubernetes-server-${os}-${arch}.tar.gz
+EOF
+
+          curl --fail --show-error --silent --location --remote-name \
+            "https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-client-${os}-${arch}.tar.gz"
+          curl --fail --show-error --silent --location --remote-name \
+            "https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-client-${os}-${arch}.tar.gz.sha256"
+          sha256sum --check --status <<EOF
+$(cat kubernetes-client-${os}-${arch}.tar.gz.sha256)  kubernetes-client-${os}-${arch}.tar.gz
+EOF
+
+          curl --fail --show-error --silent --location --remote-name \
+            "https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
+          curl --fail --show-error --silent --location --remote-name \
+            "https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/SHA256SUMS"
+          grep " etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz$" SHA256SUMS | sha256sum --check --status
+
+          tar -zxvf "kubernetes-server-${os}-${arch}.tar.gz"
+          tar -zxvf "kubernetes-client-${os}-${arch}.tar.gz"
+          tar -zxvf "etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
+
+          chmod +x "kubebuilder_${os}_${arch}"
+          chmod +x kubernetes/server/bin/kube-apiserver
+          chmod +x kubernetes/client/bin/kubectl
+          chmod +x "etcd-v${ETCD_VERSION}-${os}-${arch}/etcd"
+
+          sudo mkdir -p /usr/local/kubebuilder/bin
+          sudo mv "kubebuilder_${os}_${arch}" /usr/local/kubebuilder/bin/kubebuilder
+          sudo mv kubernetes/server/bin/kube-apiserver /usr/local/kubebuilder/bin/kube-apiserver
+          sudo mv kubernetes/server/bin/kubectl /usr/local/kubebuilder/bin/kubectl
+          sudo mv "etcd-v${ETCD_VERSION}-${os}-${arch}/etcd" /usr/local/kubebuilder/bin/etcd
         env:
           KUBEBUILDER_VERSION: 3.9.0
           KUBERNETES_VERSION: 1.26.1


### PR DESCRIPTION
### Motivation
- The GitHub Actions workflow downloaded and executed external tools and tarballs without integrity checks, creating a CI supply-chain risk. 
- The change aims to ensure artifacts used during the `Unit test` job are verified before extraction or execution while preserving the existing installation behavior and versions.

### Description
- Updated the `Install kubebuilder` step in `.github/workflows/workflow.yaml` to start with `set -euo pipefail` and to compute `os` and `arch` from `go env` for consistent filenames. 
- Replaced simple `curl -L -O` invocations with `curl --fail --show-error --silent --location --remote-name` to fail loudly on network errors. 
- Added checksum verification for `kubebuilder_${os}_${arch}` against `checksums.txt`, for Kubernetes server/client tarballs against their `.sha256` files using `sha256sum --check`, and for the etcd tarball against `SHA256SUMS`. 
- Kept the same extraction and installation steps (tar, chmod, move to `/usr/local/kubebuilder/bin`) and preserved the pinned `KUBEBUILDER_VERSION`, `KUBERNETES_VERSION`, and `ETCD_VERSION` values.

### Testing
- Inspected the modified workflow contents with `nl`/`sed` to confirm the new `Install kubebuilder` block is present and well-formed, and this check succeeded. 
- Searched the workflow with `rg` for `sha256sum --check`, `checksums.txt`, and `SHA256SUMS` to validate checksum checks were added, and this search succeeded. 
- Attempted to parse the workflow YAML via a small `python` script that calls `yaml.safe_load`, but the environment lacks `PyYAML` so YAML parsing could not be executed. 
- Attempted remote HTTP checks for upstream checksum files but received no responses in this environment, so end-to-end download verification could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7e8b98538832aaa868a71300da593)