### PR TITLE
Require leader election for CertRotator and webhook cache

### DIFF
--- a/pkg/rotator/rotator.go
+++ b/pkg/rotator/rotator.go
@@ -173,7 +173,7 @@ func AddRotator(mgr manager.Manager, cr *CertRotator) error {
 		secretKey:                   cr.SecretKey,
 		wasCAInjected:               cr.wasCAInjected,
 		webhooks:                    cr.Webhooks,
-		needLeaderElection:          cr.RequireLeaderElection,
+		needLeaderElection:          true,
 		refreshCertIfNeededDelegate: cr.refreshCertIfNeeded,
 		fieldOwner:                  cr.FieldOwner,
 		certsMounted:                cr.certsMounted,
@@ -208,9 +208,8 @@ func addNamespacedCache(mgr manager.Manager, cr *CertRotator, namespace string) 
 	if err != nil {
 		return nil, err
 	}
-	// Wrapping the cache to make sure it's also started when the manager
-	// hasn't been leader elected and CertRotator.RequireLeaderElection is false.
-	if err := mgr.Add(&cacheWrapper{Cache: c, needLeaderElection: cr.RequireLeaderElection}); err != nil {
+	// Wrapping the cache so the manager can gate startup on leader election.
+	if err := mgr.Add(&cacheWrapper{Cache: c, needLeaderElection: true}); err != nil {
 		return nil, fmt.Errorf("registering namespaced cache: %w", err)
 	}
 	return c, nil
@@ -239,8 +238,8 @@ type CertRotator struct {
 	FieldOwner             string
 	RestartOnSecretRefresh bool
 	ExtKeyUsages           *[]x509.ExtKeyUsage
-	// RequireLeaderElection should be set to true if the CertRotator needs to
-	// be run in the leader election mode.
+	// RequireLeaderElection is deprecated and ignored.
+	// CertRotator always requires leader election.
 	RequireLeaderElection bool
 	// CaCertDuration sets how long a CA cert will be valid for.
 	CaCertDuration time.Duration
@@ -273,7 +272,7 @@ type CertRotator struct {
 }
 
 func (cr *CertRotator) NeedLeaderElection() bool {
-	return cr.RequireLeaderElection
+	return true
 }
 
 // Start starts the CertRotator runnable to rotate certs and ensure the certs are ready.


### PR DESCRIPTION
### Motivation
- The repo introduced a regression where `CertRotator` and its webhook reconciler defaulted to opt-in leader election via the zero-value `RequireLeaderElection=false`, which allowed multiple replicas to concurrently rotate certificates and inject CA bundles causing webhook TLS churn and availability risk.  
- The change restores the previous safety posture by ensuring the rotator and related controller pieces participate in leader election by default while preserving the existing field for compatibility.

### Description
- Set `ReconcileWH.needLeaderElection` to `true` when constructing the reconciler in `AddRotator` so the webhook reconciler always requires leader election.  
- Register the namespaced `cacheWrapper` with `needLeaderElection: true` in `addNamespacedCache` so the cache startup is gated by leader election.  
- Mark the `CertRotator.RequireLeaderElection` field as deprecated/ignored and make `CertRotator.NeedLeaderElection()` return `true` unconditionally to force leader-election participation.  
- The code keeps the `RequireLeaderElection` field for API/backwards-compatibility but prevents the unsafe zero-value behavior.

### Testing
- Ran `go test ./pkg/rotator/...` with a 25s timeout in the environment which timed out and returned `EXIT:124`, so tests could not be completed successfully in this environment.  
- A local commit was created with the fix and the change is limited and minimal to reduce regression risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ae99f184832ab631f03b02821809)