### PR TITLE
rotator: stop exiting process on secret refresh

### DIFF
--- a/pkg/rotator/rotator.go
+++ b/pkg/rotator/rotator.go
@@ -339,8 +339,7 @@ func (cr *CertRotator) refreshCertIfNeeded() (bool, error) {
 			rotatedCA = true
 			crLog.Info("server certs refreshed")
 			if cr.RestartOnSecretRefresh {
-				crLog.Info("Secrets have been updated; exiting so pod can be restarted (This behaviour can be changed with the option RestartOnSecretRefresh)")
-				os.Exit(0)
+				crLog.Info("Secrets have been updated; RestartOnSecretRefresh is deprecated and ignored to avoid restart loops")
 			}
 			return true, nil
 		}
@@ -353,8 +352,7 @@ func (cr *CertRotator) refreshCertIfNeeded() (bool, error) {
 			}
 			crLog.Info("server certs refreshed")
 			if cr.RestartOnSecretRefresh {
-				crLog.Info("Secrets have been updated; exiting so pod can be restarted (This behaviour can be changed with the option RestartOnSecretRefresh)")
-				os.Exit(0)
+				crLog.Info("Secrets have been updated; RestartOnSecretRefresh is deprecated and ignored to avoid restart loops")
 			}
 			return true, nil
 		}


### PR DESCRIPTION
### Motivation
- The `RestartOnSecretRefresh` option caused the process to call `os.Exit(0)` inside `refreshCertIfNeeded`, enabling a Secret writer to repeatedly trigger restarts (availability DoS); the change prevents accidental restart loops while preserving API compatibility.

### Description
- Remove the forced `os.Exit(0)` calls in `refreshCertIfNeeded` and replace them with a deprecation/no-op log so certificate refreshes no longer terminate the process while still accepting the `RestartOnSecretRefresh` field for compatibility.

### Testing
- Attempted to run `go test ./pkg/rotator` and `go test -run TestDoesNotExist -count=1 ./pkg/rotator`, but tests could not complete in this environment because kubebuilder test assets (for example `/usr/local/kubebuilder/bin/etcd`) are missing, so no automated test results are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7fd4896d8832aaf9b6ba0ca3fd271)