### PR TITLE
ci: group CodeQL action Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,7 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "chore"
+    groups:
+      codeql-action:
+        patterns:
+        - "github/codeql-action/*"


### PR DESCRIPTION
Groups `github/codeql-action/*` Dependabot updates so CodeQL `init`, `autobuild`, `analyze`, and `upload-sarif` stay on the same action version. This avoids partial CodeQL action bumps where `init` writes config for one version and later CodeQL steps run another version.

Related to #522.